### PR TITLE
authentication for server side render with axios interceptors.

### DIFF
--- a/app/api/preRenderAuthentication.js
+++ b/app/api/preRenderAuthentication.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+/*
+If it's initialized with a cookie, it sets it as a global interceptor
+if it gets called with no arguemnts, it deletes *all* request intercepotrs
+*/
+
+export default function ssrAuth(cookie){
+    if(arguments.length === 0){
+        axios.interceptors.request.handlers = [];
+    }else{
+    axios.interceptors.request.use(function(config) {
+            config.headers['cookie'] = cookie;
+    }, function(error) {
+      return Promise.reject(error);
+        });
+    }
+}
+


### PR DESCRIPTION
**UPDATE 2016/11/30**
This _still_ method bleeds data between users
**IMPORTANT**


Same as #184  but with significantly lower footprint

Before:
if user comes to website with active session cookie and you call server side rendering through static needs methods, you don't see user session information, because the request is made from server to server.

Now:
when logged in user comes to website, we attach his cookie to all requests for the duration that preRenderMiddleware function renders all the promises, then we delete the interceptor.

Pros:
- All server-side rendering can be done as if user was authenticated
- We don't need to modify specific routes with express to get user specific data on server-side rendering, and we can just use static need methods that work for unauthenticated and authenticated users

Cons:
- Relies on axios
- If developer is using interceptors for something else, then they'd need to modify preRenderAuthentication.js because it deletes all other request interceptors on default axios instance
