### PR TITLE
use setup script instead of postInstall

### DIFF
--- a/docs/deployment/Heroku.md
+++ b/docs/deployment/Heroku.md
@@ -4,6 +4,9 @@ Heroku
 ```bash
 heroku create
 
+# Run build after npm install
+heroku config:set BUILD_ASSETS=true
+
 # Deploy to Heroku server
 git push heroku master
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "npm run clean && npm run build:prod && npm run build:node",
     "test": "cross-env NODE_ENV=test karma start",
     "test:watch": "cross-env NODE_ENV=test npm test -- --watch --no-single-run",
-    "postinstall": "npm run build"
+    "postInstall": "if [ $BUILD_ASSETS ]; then npm run build; fi"
   },
   "author": "Choon Ken Ding",
   "license": "MIT",


### PR DESCRIPTION
means you aren't running full prod build when following dev steps, saving $$$
fixes #167
