### PR TITLE
remove bluebird in favor of es6-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-0": "^6.5.0",
     "bcrypt-nodejs": "0.0.3",
-    "bluebird": "^3.4.6",
     "body-parser": "^1.15.0",
     "chai": "^3.5.0",
     "classnames": "^2.2.3",

--- a/server/db/mongo/connect.js
+++ b/server/db/mongo/connect.js
@@ -3,6 +3,8 @@ import path from 'path';
 import mongoose from 'mongoose';
 import { db } from './constants';
 
+mongoose.Promise = global.Promise;
+
 export default () => {
   // Find the appropriate database to connect to, default to localhost if not found.
   const connect = () => {


### PR DESCRIPTION
(Resolves #477) Sheds redundant bluebird package, and adds:

```javascript
// to `server/db/mongo/connect.js`
mongoose.Promise = global.Promise;
```
Credit: @ZeroCho
