### PR TITLE
Change default Heroku MongoDB (Compose MongoDB --> MongoLab)

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,6 +5,6 @@
   "logo": "https://node-js-sample.herokuapp.com/node.svg",
   "keywords": ["node", "express", "static", "react", "webpack", "mongodb"],
   "addons" : [
-  	"mongohq"
+  	"mongolab"
   ]
 }


### PR DESCRIPTION
When a new user wants to test the reactGo, by pressing the *Deploy to Heroku* Button, the default db is Compose MongoDB, and its default (and minimum) price is $18.00/Month. I thinks that's not very helpful for those new devs that just want to give a try. If we change the default db to MongoLab, the default deployment is free.

-----------------------------------------

Compose MongoDB:
![herokupaid](https://cloud.githubusercontent.com/assets/12717998/18628512/d6ba3284-7e60-11e6-9580-9b45c8f742e3.PNG)

---------------------------------------------

MongoLab:
![herokufree](https://cloud.githubusercontent.com/assets/12717998/18628517/df4d78ca-7e60-11e6-8599-94c2eed605bc.PNG)

