### PR TITLE
Allow SSR to use authentication through axios instances

### DIFF
--- a/app/client.jsx
+++ b/app/client.jsx
@@ -7,6 +7,7 @@ import createRoutes from 'routes';
 import * as types from 'types';
 import configureStore from 'store/configureStore';
 import preRenderMiddleware from 'middlewares/preRenderMiddleware';
+import axios from 'axios';
 
 // Grab the state from a global injected into
 // server-generated HTML
@@ -15,6 +16,8 @@ const initialState = window.__INITIAL_STATE__;
 const store = configureStore(initialState, browserHistory);
 const history = syncHistoryWithStore(browserHistory, store);
 const routes = createRoutes(store);
+
+const api = axios.create();
 
 /**
  * Callback function handling frontend route changes.
@@ -32,7 +35,7 @@ function onUpdate() {
   }
 
   store.dispatch({ type: types.CREATE_REQUEST });
-  preRenderMiddleware(this.state)
+  preRenderMiddleware({ props: this.state, api })
   .then(data => {
     return store.dispatch({ type: types.REQUEST_SUCCESS, data });
   });

--- a/app/fetch-data/fetchVoteData.js
+++ b/app/fetch-data/fetchVoteData.js
@@ -1,9 +1,8 @@
 import { voteService } from 'services';
 
-const fetchData = () => {
-  return voteService.getTopics()
+const fetchData = ({ api }) => {
+  return voteService.getTopics(api)
           .then(res => res.data);
 };
 
 export default fetchData;
-

--- a/app/middlewares/preRenderMiddleware.js
+++ b/app/middlewares/preRenderMiddleware.js
@@ -1,10 +1,9 @@
 const defaultFetchData = () => Promise.resolve();
 
-function preRenderMiddleware({ routes, location, params }) {
+function preRenderMiddleware({ props: { routes, location, params }, api }) {
   const matchedRoute = routes[routes.length - 1];
   const fetchDataHandler = matchedRoute.fetchData || defaultFetchData;
-  return fetchDataHandler(params);
+  return fetchDataHandler({ params, api });
 }
 
 export default preRenderMiddleware;
-

--- a/app/server.jsx
+++ b/app/server.jsx
@@ -19,7 +19,7 @@ axios.defaults.baseURL = `http://${clientConfig.host}:${clientConfig.port}`;
 
 
 const analtyicsScript =
-  typeof trackingID === "undefined" ? ``
+  typeof trackingID === 'undefined' ? ''
   :
   `<script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -40,9 +40,7 @@ const analtyicsScript =
  * however the assignement  does not, so it is undefined for the type check above.
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting
  */
-const trackingID  = "'UA-########-#'";
-
-
+const trackingID = "'UA-########-#'";
 
 
 /*
@@ -93,7 +91,17 @@ export default function render(req, res) {
       // This method waits for all render component
       // promises to resolve before returning to browser
       store.dispatch({ type: types.CREATE_REQUEST });
-      preRenderMiddleware(props)
+      let api = axios;
+      // This allows us to fetch data from API server during SSR
+      // that requires authentication. Otherwise axios requests would not
+      // have the user session set.
+      if (authenticated) {
+        api = axios.create({
+          headers: { cookie: req.headers.cookie },
+          baseURL: `http://${clientConfig.host}:${clientConfig.port}`
+        });
+      }
+      preRenderMiddleware({ props, api })
       .then(data => {
         store.dispatch({ type: types.REQUEST_SUCCESS, data });
         const componentHTML = renderToString(

--- a/app/services/topics.js
+++ b/app/services/topics.js
@@ -1,8 +1,5 @@
-import axios from 'axios';
-
 const service = {
-  getTopics: () => axios.get('/topic')
+  getTopics: (api) => api.get('/topic')
 };
 
 export default service;
-


### PR DESCRIPTION
This is to solve #435 and #225, taking inspiration from #184.

The problem is that on server-side rendering, the server sends axios requests without the user's cookie set as a header at present, so the user will never be authenticated and, if the API requires you to be logged in, will fail.

To fix this, two different instances of axios are created, one on the server which sets the user's cookie header in its config, and the client one which is just the default axios instance. These are passed through to the fetchData handlers, so you can call api.get/api.post etc from your fetch handler, and it will (automagically) attach the user's cookie to requests.

This means you can finally do SSR even if your API requires you to log in. You can also now access req.user on the API too to do cool things like find objects belonging to a specific user.

(P.S. My first ever pull request - exciting!) :)
