### PR TITLE
Bump stylelint v to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "redux-mock-store": "1.1.2",
     "sinon": "^1.17.5",
     "stylelint": "^7.1.0",
-    "stylelint-webpack-plugin": "^0.3.1"
+    "stylelint-webpack-plugin": "^0.4.2"
   },
   "engines": {
     "node": "5.x"


### PR DESCRIPTION
Git clone the boilerplate, then
rm -rf node_modules
npm i 
npm run dev => `Error: Cannot find module 'stylelint/dist/formatters/stringFormatter'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.Module._load (module.js:388:25)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
`

This version bump of the stylelint-webpack-plugin fixes it.