### PR TITLE
Fix failed imports with named export

### DIFF
--- a/app/fetch-data/index.js
+++ b/app/fetch-data/index.js
@@ -1,4 +1,2 @@
-import { fetchVoteData } from './fetchVoteData';
-
-export default { fetchVoteData };
+export { default as fetchVoteData } from './fetchVoteData';
 

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -1,3 +1,2 @@
-import voteService from './topics';
+export { default as voteService } from './topics';
 
-export default { voteService };


### PR DESCRIPTION
## Why
#784

## High Level Changes
Removed default export as we see fetch-data and services as utility modules that
expose distinct functions, not necessarily grouped and imported together.