### PR TITLE
Remove inline environment variables webpack plugin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+2.1.1
+===
+- PR #786 - Fixed failed imports with named export
+- PR #780 - Eslint fix
+- Replace external inline-environment-variables-webpack-plugin with
+  webpack.EvnrionmentPlugin
+
 2.1
 ===
 - #766

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "helmet": "^2.1.2",
-    "inline-environment-variables-webpack-plugin": "1.1.0",
     "json-loader": "^0.5.4",
     "lodash": "^4.16.2",
     "method-override": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webpack-node",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Your One-Stop solution for a full-stack app with ES6/ES2015 React.js featuring universal Redux, React Router, React Router Redux Hot reloading, CSS modules, Express 4.x, and multiple ORMs.",
   "repository": "https://github.com/choonkending/react-webpack-node",
   "main": "index.js",

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -1,7 +1,6 @@
 var path = require('path');
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var InlineEnviromentVariablesPlugin = require('inline-environment-variables-webpack-plugin');
 
 var commonConfig = require('./common.config');
 var commonLoaders = commonConfig.commonLoaders;
@@ -73,7 +72,7 @@ module.exports = [
           __DEVCLIENT__: false,
           __DEVSERVER__: false
         }),
-        new InlineEnviromentVariablesPlugin({ NODE_ENV: 'production' })
+        new webpack.EnvironmentPlugin(['NODE_ENV'])
     ],
     postcss: postCSSConfig
   }, {
@@ -117,8 +116,8 @@ module.exports = [
           __DEVCLIENT__: false,
           __DEVSERVER__: false
         }),
+        new webpack.EnvironmentPlugin(['NODE_ENV']),
         new webpack.IgnorePlugin(/vertx/),
-        new InlineEnviromentVariablesPlugin({ NODE_ENV: 'production' }),
         new webpack.optimize.UglifyJsPlugin({
           compressor: {
             warnings: false


### PR DESCRIPTION
- Part of #705 

## High Level Changes
- Replace [inline-environment-variables-webpack-plugin](https://github.com/tikotzky/inline-environment-variables-webpack-plugin) with [webpack.EnvironmentPlugin](https://github.com/webpack/docs/wiki/list-of-plugins#environmentplugin)

**Background**
- Was introduced in https://github.com/reactGo/reactGo/issues/157 but with this change we can remove an extra dependency