### PR TITLE
Move tracking id to env

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
+2.2.1
+===
+- PR #795 - Convert tracking ID for google analytics into a environment variable
+With this change, we also extracted createScript files from pageRenderer
+
 2.2.0
 ===
-- PR #792 0 Centralize /config
+- PR #792 - Centralize /config
 Having config/ folders in app and server with shared functionality makes it harder to understand and maintain our app.
 
 With this change, we move our config/ to the root level.

--- a/app/utils/createScripts.js
+++ b/app/utils/createScripts.js
@@ -1,0 +1,20 @@
+import { GOOGLE_ANALYTICS_ID } from '../../config/env';
+
+const createAppScript = () => {
+  return '<script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>';
+};
+
+const createTrackingScript = () => {
+  return GOOGLE_ANALYTICS_ID ? createAnalyticsSnippet(GOOGLE_ANALYTICS_ID) : '';
+};
+
+const createAnalyticsSnippet = id =>
+`<script>
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga('create', '${id}', 'auto');
+ga('send', 'pageview');
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>`;
+
+export { createTrackingScript, createAppScript };
+

--- a/app/utils/pageRenderer.jsx
+++ b/app/utils/pageRenderer.jsx
@@ -24,7 +24,7 @@ const buildPage = ({ componentHTML, initialState, headAssets }) => {
   <body>
     <div id="app">${componentHTML}</div>
     <script>window.__INITIAL_STATE__ = ${JSON.stringify(initialState)}</script>
-    ${createScriptTags()}
+    ${createAppScript()}
   </body>
 </html>`;
 };
@@ -41,7 +41,7 @@ ga('send', 'pageview');
 </script>
 <script async src='https://www.google-analytics.com/analytics.js'></script>`;
 
-const createScriptTags = () => {
+const createAppScript = () => {
   return '<script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>';
 };
 

--- a/app/utils/pageRenderer.jsx
+++ b/app/utils/pageRenderer.jsx
@@ -3,7 +3,7 @@ import { renderToString } from 'react-dom/server';
 import { Provider } from 'react-redux';
 import { RouterContext } from 'react-router';
 import Helmet from 'react-helmet';
-import { GOOGLE_ANALYTICS_ID } from '../../config/env';
+import { createAppScript, createTrackingScript } from './createScripts';
 
 const createApp = (store, props) => renderToString(
   <Provider store={store}>
@@ -27,22 +27,6 @@ const buildPage = ({ componentHTML, initialState, headAssets }) => {
     ${createAppScript()}
   </body>
 </html>`;
-};
-
-const createTrackingScript = () => {
-  return GOOGLE_ANALYTICS_ID ? createAnalyticsSnippet(GOOGLE_ANALYTICS_ID) : '';
-};
-
-const createAnalyticsSnippet = id =>
-`<script>
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', '${id}', 'auto');
-ga('send', 'pageview');
-</script>
-<script async src='https://www.google-analytics.com/analytics.js'></script>`;
-
-const createAppScript = () => {
-  return '<script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>';
 };
 
 export default (store, props) => {

--- a/app/utils/pageRenderer.jsx
+++ b/app/utils/pageRenderer.jsx
@@ -19,6 +19,7 @@ const buildPage = ({ componentHTML, initialState, headAssets }) => {
     ${headAssets.title.toString()}
     ${headAssets.meta.toString()}
     ${headAssets.link.toString()}
+    ${createTrackingScript()}
   </head>
   <body>
     <div id="app">${componentHTML}</div>
@@ -28,24 +29,21 @@ const buildPage = ({ componentHTML, initialState, headAssets }) => {
 </html>`;
 };
 
-const createScriptTags = () => {
-  const analyticsScript = GOOGLE_ANALYTICS_ID ? createTrackingScript(GOOGLE_ANALYTICS_ID) : '';
-  return `${analyticsScript}<script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>`;
+const createTrackingScript = () => {
+  return GOOGLE_ANALYTICS_ID ? createAnalyticsSnippet(GOOGLE_ANALYTICS_ID) : '';
 };
 
-/*
- * Consider async script loading if you support IE9+
- * https://developers.google.com/analytics/devguides/collection/analyticsjs/
- */
-const createTrackingScript = trackingID =>
+const createAnalyticsSnippet = id =>
 `<script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', '${trackingID}', 'auto');
-  ga('send', 'pageview');
-  </script>`;
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga('create', '${id}', 'auto');
+ga('send', 'pageview');
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>`;
+
+const createScriptTags = () => {
+  return '<script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>';
+};
 
 export default (store, props) => {
   const initialState = store.getState();

--- a/app/utils/pageRenderer.jsx
+++ b/app/utils/pageRenderer.jsx
@@ -3,23 +3,7 @@ import { renderToString } from 'react-dom/server';
 import { Provider } from 'react-redux';
 import { RouterContext } from 'react-router';
 import Helmet from 'react-helmet';
-import { trackingID } from '../../config/app';
-
-/*
- * Consider async script loading if you support IE9+
- * https://developers.google.com/analytics/devguides/collection/analyticsjs/
- */
-const createTrackingScript = trackingID =>
-`<script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', ${trackingID}, 'auto');
-  ga('send', 'pageview');
-  </script>`;
-
-const analyticsScript = createTrackingScript(trackingID);
+import { GOOGLE_ANALYTICS_ID } from '../../config/env';
 
 const createApp = (store, props) => renderToString(
   <Provider store={store}>
@@ -27,11 +11,7 @@ const createApp = (store, props) => renderToString(
   </Provider>
 );
 
-const createScriptTags = () => {
-  return `${analyticsScript}<script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>`;
-};
-
-const buildPage = ({ componentHTML, initialState, headAssets, analyticsScript }) => {
+const buildPage = ({ componentHTML, initialState, headAssets }) => {
   return `
 <!doctype html>
 <html>
@@ -48,10 +28,29 @@ const buildPage = ({ componentHTML, initialState, headAssets, analyticsScript })
 </html>`;
 };
 
+const createScriptTags = () => {
+  const analyticsScript = GOOGLE_ANALYTICS_ID ? createTrackingScript(GOOGLE_ANALYTICS_ID) : '';
+  return `${analyticsScript}<script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>`;
+};
+
+/*
+ * Consider async script loading if you support IE9+
+ * https://developers.google.com/analytics/devguides/collection/analyticsjs/
+ */
+const createTrackingScript = trackingID =>
+`<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  ga('create', '${trackingID}', 'auto');
+  ga('send', 'pageview');
+  </script>`;
+
 export default (store, props) => {
   const initialState = store.getState();
   const componentHTML = createApp(store, props);
   const headAssets = Helmet.rewind();
-  return buildPage({ componentHTML, initialState, headAssets, analyticsScript });
+  return buildPage({ componentHTML, initialState, headAssets });
 };
 

--- a/config/env.js
+++ b/config/env.js
@@ -6,3 +6,5 @@ export const ENV = process.env.NODE_ENV || 'development';
 
 export const DB_TYPE = process.env.DB_TYPE || DB_TYPES.MONGO;
 
+export const GOOGLE_ANALYTICS_ID = process.env.GOOGLE_ANALYTICS_ID || null;
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webpack-node",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Your One-Stop solution for a full-stack app with ES6/ES2015 React.js featuring universal Redux, React Router, React Router Redux Hot reloading, CSS modules, Express 4.x, and multiple ORMs.",
   "repository": "https://github.com/choonkending/react-webpack-node",
   "main": "index.js",


### PR DESCRIPTION
Part of #742 

# High Level Changes
- Use tracking ID as an environment variable. We could have different IDs based on different environments (staging, UAT)
- Update analytics snippet to be an `async` script, and place it in head as recommended.
  ⚠️ Typically not a fan of adding scripts to <head> as they are blocking, but I think this is a special case
- Move script creation functions to `createScripts.js`
