### PR TITLE
Simplify npm commands

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+2.2.4
+===
+- PR #802
+  - Add `npm run build` as part of `npm start`
+  - Remove postinstall command - we no longer need it! (Running `npm start` or
+    `npm run dev` both build the app respectively
+  - Remove greenkeeper command in package.json as we no longer use it
+
 2.2.3
 ===
 - PR #800

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,8 +41,9 @@ npm install
 #### Development
 
 ```bash
+## Note: You need MongoDB running
 # Starts the server with Hot Reloading
-# Run webpack through webpack.config.dev.js
+# Run webpack through webpack.config.dev-client.js and webpack.config.dev-server.js
 npm run dev
 
 ```
@@ -52,11 +53,10 @@ npm run dev
 Run the commands below for a production build, i.e. what is deployed to Heroku. If you are deploying to Heroku or similar, we assume that you are serving the pages over HTTPS.
 
 ```bash
+## Note: You need MongoDB running
+
 # Clean public folder
 # Run webpack through webpack.config.prod.js
-npm run build
-
 # Start server
-## Note: You need MongoDB running
 npm start
 ```

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "build:dev": "cross-env NODE_ENV=development webpack ---debug --colors --display-error-details --config ./webpack/webpack.config.dev-server.js",
     "build": "npm run clean && cross-env NODE_ENV=production webpack --colors --display-error-details --config ./webpack/webpack.config.prod.js",
     "test": "cross-env NODE_ENV=test karma start",
-    "test:watch": "cross-env NODE_ENV=test npm test -- --watch --no-single-run",
-    "keep-green": "git merge master && rm -rf node_modules && npm install && npm start"
+    "test:watch": "cross-env NODE_ENV=test npm test -- --watch --no-single-run"
   },
   "author": "Choon Ken Ding",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "build": "npm run clean && cross-env NODE_ENV=production webpack --colors --display-error-details --config ./webpack/webpack.config.prod.js",
     "test": "cross-env NODE_ENV=test karma start",
     "test:watch": "cross-env NODE_ENV=test npm test -- --watch --no-single-run",
-    "postinstall": "npm run build",
     "keep-green": "git merge master && rm -rf node_modules && npm install && npm start"
   },
   "author": "Choon Ken Ding",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint --ext .js,.jsx app server",
     "lint:fix": "eslint --ext .js,.jsx app server --fix",
     "clean": "rimraf public && rimraf compiled",
-    "start": "cross-env NODE_ENV=production node compiled/server.js",
+    "start": "npm run build && cross-env NODE_ENV=production node compiled/server.js",
     "dev": "cross-env NODE_ENV=development nodemon",
     "build:dev": "cross-env NODE_ENV=development webpack ---debug --colors --display-error-details --config ./webpack/webpack.config.dev-server.js",
     "build": "npm run clean && cross-env NODE_ENV=production webpack --colors --display-error-details --config ./webpack/webpack.config.prod.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webpack-node",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Your One-Stop solution for a full-stack app with ES6/ES2015 React.js featuring universal Redux, React Router, React Router Redux Hot reloading, CSS modules, Express 4.x, and multiple ORMs.",
   "repository": "https://github.com/choonkending/react-webpack-node",
   "main": "index.js",


### PR DESCRIPTION
# Why?

-  To run a prod build, we will always do the following:
```bash
npm run build && npm start
```

Simplifying this a bit, we could just do `npm run build` as part of `npm start`. This also makes the production command consistent with the dev command.

Commands are now:
```bash
// Builds and runs dev server
npm run dev 

// Builds and runs production server
npm start
```

- Remove `postinstall` as no longer needed with the above change
- Removing `keep-green` command as we disabled greenkeeper
