### PR TITLE
Update README with new demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ _Formerly known as choonkending/react-webpack-node_
 [npm-link]: http://badge.fury.io/js/react-webpack-node
 
 
-#### Demo site:
-
-[https://react-webpack-node.herokuapp.com/](https://react-webpack-node.herokuapp.com/)
+#### Demo site: [**https://demo-reactgo.herokuapp.com/**](https://demo-reactgo.herokuapp.com/)
 
 ## Features:
 - ~~isomorphic~~ [**universal**](https://medium.com/@ghengeveld/isomorphism-vs-universal-javascript-4b47fb481beb#.4x2t3jlmx) Rendering


### PR DESCRIPTION
Rename 

`react-webpack-node` (old name) to `demo-reactgo` for the heroku deploy