### PR TITLE
Rename pre rendermiddleware

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+2.2.5
+===
+- PR #803 - Minor spelling fixes
+- PR #805 - Update README with new demo site (https://demo-reactgo.herokuapp.com)
+- PR #807 - Rename middlewares/preRenderMiddleware -> utils/fetchDataForRoute
+
 2.2.4
 ===
 - PR #802

--- a/app/client.jsx
+++ b/app/client.jsx
@@ -6,7 +6,7 @@ import { syncHistoryWithStore } from 'react-router-redux';
 import createRoutes from './routes';
 import * as types from './types';
 import configureStore from './store/configureStore';
-import preRenderMiddleware from './middlewares/preRenderMiddleware';
+import fetchDataForRoute from './utils/fetchDataForRoute';
 
 // Grab the state from a global injected into
 // server-generated HTML
@@ -32,10 +32,10 @@ function onUpdate() {
   }
 
   store.dispatch({ type: types.CREATE_REQUEST });
-  preRenderMiddleware(this.state)
-  .then(data => {
-    return store.dispatch({ type: types.REQUEST_SUCCESS, data });
-  });
+  fetchDataForRoute(this.state)
+    .then(data => {
+      return store.dispatch({ type: types.REQUEST_SUCCESS, data });
+    });
 }
 
 

--- a/app/server.jsx
+++ b/app/server.jsx
@@ -3,9 +3,9 @@ import { createMemoryHistory, match } from 'react-router';
 import createRoutes from './routes';
 import configureStore from './store/configureStore';
 import * as types from './types';
-import preRenderMiddleware from './middlewares/preRenderMiddleware';
 import { baseURL } from '../config/app';
 import pageRenderer from './utils/pageRenderer';
+import fetchDataForRoute from './utils/fetchDataForRoute';
 
 // configure baseURL for axios requests (for serverside API calls)
 axios.defaults.baseURL = baseURL;
@@ -58,16 +58,16 @@ export default function render(req, res) {
       // This method waits for all render component
       // promises to resolve before returning to browser
       store.dispatch({ type: types.CREATE_REQUEST });
-      preRenderMiddleware(props)
-      .then(data => {
-        store.dispatch({ type: types.REQUEST_SUCCESS, data });
-        const html = pageRenderer(store, props);
-        res.status(200).send(html);
-      })
-      .catch(err => {
-        console.error(err);
-        res.status(500).json(err);
-      });
+      fetchDataForRoute(props)
+        .then(data => {
+          store.dispatch({ type: types.REQUEST_SUCCESS, data });
+          const html = pageRenderer(store, props);
+          res.status(200).send(html);
+        })
+        .catch(err => {
+          console.error(err);
+          res.status(500).json(err);
+        });
     } else {
       res.sendStatus(404);
     }

--- a/app/utils/fetchDataForRoute.js
+++ b/app/utils/fetchDataForRoute.js
@@ -1,10 +1,10 @@
 const defaultFetchData = () => Promise.resolve();
 
-function preRenderMiddleware({ routes, params }) {
+function fetchDataForRoute({ routes, params }) {
   const matchedRoute = routes[routes.length - 1];
   const fetchDataHandler = matchedRoute.fetchData || defaultFetchData;
   return fetchDataHandler(params);
 }
 
-export default preRenderMiddleware;
+export default fetchDataForRoute;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webpack-node",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Your One-Stop solution for a full-stack app with ES6/ES2015 React.js featuring universal Redux, React Router, React Router Redux Hot reloading, CSS modules, Express 4.x, and multiple ORMs.",
   "repository": "https://github.com/choonkending/react-webpack-node",
   "main": "index.js",


### PR DESCRIPTION
Related to https://github.com/reactGo/reactGo/issues/804

# High Level Changes
- Rename preRenderMiddleware -> fetchDataForRoute

Move middlewares/preRenderMiddleware -> utils/fetchDataForRoute. Moving out of
the middlewares folder as I wish to eliminate the confusion. Middlewares would
typically get associated with redux or express.