### PR TITLE
remove react-addons-test-utils from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "mocha": "^3.2.0",
     "nodemon": "^1.10.2",
     "null-loader": "^0.1.1",
-    "react-addons-test-utils": "^15.4.1",
     "react-transform-catch-errors": "^1.0.2",
     "redux-mock-store": "1.1.2",
     "sinon": "^1.17.5"


### PR DESCRIPTION
Seems like this package isn't used any more, guess it was superseeded by `enzyme` ? 