### PR TITLE
Code split

### DIFF
--- a/app/client.jsx
+++ b/app/client.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
-import { Router, browserHistory } from 'react-router';
+import { match, Router, browserHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 import createRoutes from './routes';
 import * as types from './types';
@@ -41,9 +41,10 @@ function onUpdate() {
 
 // Router converts <Route> element hierarchy to a route config:
 // Read more https://github.com/rackt/react-router/blob/latest/docs/Glossary.md#routeconfig
-render(
-  <Provider store={store}>
-    <Router history={history} onUpdate={onUpdate}>
-      {routes}
-    </Router>
-  </Provider>, document.getElementById('app'));
+match({routes, history}, (error, redirectLocation, renderProps) => {
+  render(
+    <Provider store={store}>
+      <Router {...renderProps} onUpdate={onUpdate}/>
+    </Provider>, document.getElementById('app')
+  );
+});

--- a/app/pages/index.js
+++ b/app/pages/index.js
@@ -1,6 +1,0 @@
-export { default as App } from 'pages/App';
-export { default as Vote} from 'pages/Vote';
-export { default as Dashboard } from 'pages/Dashboard';
-export { default as LoginOrRegister } from 'pages/LoginOrRegister';
-export { default as About } from 'pages/About';
-

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
-import { Route, IndexRoute } from 'react-router';
-import { fetchVoteData } from './fetch-data';
-import { App, Vote, Dashboard, About, LoginOrRegister } from './pages';
+import {Route, IndexRoute} from 'react-router';
+import {fetchVoteData} from './fetch-data';
+import {App} from './pages';
+
+const getLoginComponent     = (l, c) => require.ensure([], () => c(null, require('./pages/LoginOrRegister').default));
+const getVoteComponent      = (l, c) => require.ensure([], () => c(null, require('./pages/Vote').default));
+const getDashboardComponent = (l, c) => require.ensure([], () => c(null, require('./pages/Dashboard').default));
+const getAboutComponent     = (l, c) => require.ensure([], () => c(null, require('./pages/About').default));
 
 /*
  * @param {Redux Store}
@@ -29,12 +34,13 @@ export default (store) => {
     }
     callback();
   };
+  
   return (
     <Route path="/" component={App}>
-      <IndexRoute component={Vote} fetchData={fetchVoteData} />
-      <Route path="login" component={LoginOrRegister} onEnter={redirectAuth} />
-      <Route path="dashboard" component={Dashboard} onEnter={requireAuth} />
-      <Route path="about" component={About} />
+      <IndexRoute getComponent={getVoteComponent} fetchData={fetchVoteData} />
+      <Route path="about" getComponent={getAboutComponent} />
+      <Route path="dashboard" getComponent={getDashboardComponent} onEnter={requireAuth} />
+      <Route path="login" getComponent={getLoginComponent} onEnter={redirectAuth} />
     </Route>
   );
 };

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Route, IndexRoute} from 'react-router';
 import {fetchVoteData} from './fetch-data';
-import {App} from './pages';
+import App from './pages/App';
 
 const getLoginComponent     = (l, c) => require.ensure([], () => c(null, require('./pages/LoginOrRegister').default));
 const getVoteComponent      = (l, c) => require.ensure([], () => c(null, require('./pages/Vote').default));

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.9.0",
-    "webpack-hot-middleware": "^2.14.0"
+    "webpack-hot-middleware": "^2.14.0",
+    "webpack-manifest-plugin": "^1.1.0"
   }
 }

--- a/server/render/createScripts.js
+++ b/server/render/createScripts.js
@@ -1,7 +1,22 @@
-import { GOOGLE_ANALYTICS_ID } from '../../config/env';
+import fs from 'fs';
+import path from 'path';
+import { ENV, GOOGLE_ANALYTICS_ID } from '../../config/env';
+
+// Use fs.readFileSync(...) instead of require(...) to avoid webpack complaining about missing file
+const manifestPath = path.join(process.cwd(), 'public/assets/app-manifest.json');
+
+let manifest = {'common.js': 'common.js', 'vendor.js': 'vendor.js', 'app.js': 'app.js'};
+
+if (ENV === 'production' && fs.existsSync(manifestPath)) {
+  manifest = JSON.parse(fs.readFileSync(manifestPath), 'utf8');
+}
 
 const createAppScript = () => {
-  return '<script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>';
+  return `
+    <script src="/assets/${manifest['common.js']}"></script>
+    <script src="/assets/${manifest['vendor.js']}"></script>
+    <script src="/assets/${manifest['app.js']}"></script>
+  `;
 };
 
 const createTrackingScript = () => {

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -1,5 +1,7 @@
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const ManifestPlugin = require('webpack-manifest-plugin');
+const PATHS = require('./paths');
 
 module.exports = ({ production = false, browser = false } = {}) => {
   const bannerOptions = { raw: true, banner: 'require("source-map-support").install();' };
@@ -13,6 +15,15 @@ module.exports = ({ production = false, browser = false } = {}) => {
   }
   if (!production && browser) {
     return [
+      // create a common chunk in the vendor entry, and
+      // put the webpackjsonp manifest in a common chunk
+      // this makes sure that chunks hashes doesn't change too often
+      new webpack.optimize.CommonsChunkPlugin({
+          path: PATHS.assets,
+          names: ['vendor', 'common'],
+          filename: '[name].js',
+          minChuncks: Infinity
+      }),
       new webpack.EnvironmentPlugin(['NODE_ENV']),
       new webpack.HotModuleReplacementPlugin(),
       new webpack.NoEmitOnErrorsPlugin()
@@ -27,6 +38,20 @@ module.exports = ({ production = false, browser = false } = {}) => {
   }
   if (production && browser) {
     return [
+      new ManifestPlugin({
+          fileName: 'app-manifest.json',
+          stripSrc: true
+      }),
+
+      // create a common chunk in the vendor entry, and
+      // put the webpackjsonp manifest in a common chunk
+      // this makes sure that chunks hashes doesn't change too often
+      new webpack.optimize.CommonsChunkPlugin({
+          path: PATHS.assets,
+          names: ['vendor', 'common'],
+          filename: '[name].[chunkhash].chunk.js',
+          minChuncks: Infinity
+      }),
       new webpack.EnvironmentPlugin(['NODE_ENV']),
       new ExtractTextPlugin({
         filename: 'styles/main.css',

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -9,6 +9,8 @@ module.exports = ({ production = false, browser = false } = {}) => {
 
   if (!production && !browser) {
     return [
+      // Use Infinity to prevent code-split on the server
+      new webpack.optimize.MinChunkSizePlugin({minChunkSize: Infinity}),
       new webpack.EnvironmentPlugin(['NODE_ENV']),
       new webpack.BannerPlugin(bannerOptions)
     ];
@@ -24,6 +26,7 @@ module.exports = ({ production = false, browser = false } = {}) => {
           filename: '[name].js',
           minChuncks: Infinity
       }),
+      new webpack.optimize.MinChunkSizePlugin({minChunkSize: 10000}),
       new webpack.EnvironmentPlugin(['NODE_ENV']),
       new webpack.HotModuleReplacementPlugin(),
       new webpack.NoEmitOnErrorsPlugin()
@@ -31,6 +34,8 @@ module.exports = ({ production = false, browser = false } = {}) => {
   }
   if (production && !browser) {
     return [
+      // Use Infinity to prevent code-split on the server
+      new webpack.optimize.MinChunkSizePlugin({minChunkSize: Infinity}),
       new webpack.EnvironmentPlugin(['NODE_ENV']),
       new webpack.BannerPlugin(bannerOptions),
       new webpack.optimize.UglifyJsPlugin({ compress })
@@ -52,6 +57,7 @@ module.exports = ({ production = false, browser = false } = {}) => {
           filename: '[name].[chunkhash].chunk.js',
           minChuncks: Infinity
       }),
+      new webpack.optimize.MinChunkSizePlugin({minChunkSize: 10000}),
       new webpack.EnvironmentPlugin(['NODE_ENV']),
       new ExtractTextPlugin({
         filename: 'styles/main.css',

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -45,12 +45,15 @@ module.exports = (env = '') => {
   const prodBrowserRender = {
     devtool: 'cheap-module-source-map',
     context: PATHS.app,
-    entry: { app: ['./client'] },
+    entry: {
+      app: ['./client'],
+      vendor: ['react', 'react-dom', 'react-router', 'redux', 'react-router-redux', 'react-helmet']
+    },
     node,
     output: {
       path: PATHS.assets,
       filename: '[name].js', // filename: '[name].[hash:6].js',
-      chunkFilename: '[name].[chunkhash:6].js', // for code splitting. will work without but useful to set
+      chunkFilename: '[name].[chunkhash].chunk.js', // for code splitting. will work without but useful to set
       publicPath: PATHS.public
     },
     module: { rules: rules({ production: true, browser: true }) },
@@ -61,7 +64,10 @@ module.exports = (env = '') => {
   const devBrowserRender = {
     devtool: 'eval',
     context: PATHS.app,
-    entry: { app: ['./client', hotMiddlewareScript] },
+    entry: {
+      app: ['./client', hotMiddlewareScript],
+      vendor: ['react', 'react-dom', 'react-router', 'redux', 'react-router-redux', 'react-helmet']
+    },
     node,
     output: {
       path: PATHS.assets,


### PR DESCRIPTION
Enables code splitting by using dynamic entry points in `routes.jsx`

high level features:

* enables code splitting on client
    - hashed chunks in prod mode (for caching and cache-busting)
    - named (id) in dev mode
* disables code splitting on server
* uses a webpack manifest file to make sure vendor chunks does not change unless code changes
* adds a vendor chunk as an example (the actual content of this can easily be changed though)

Please ask any questions regarding the implementation you might have.