### PR TITLE
ActiveClassName doesn't work

### DIFF
--- a/app/containers/Navigation.jsx
+++ b/app/containers/Navigation.jsx
@@ -38,4 +38,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, { logOut })(Navigation);
+export default connect(mapStateToProps, { logOut }, null, {pure:false})(Navigation);


### PR DESCRIPTION
following the fix proposed here - https://github.com/react-bootstrap/react-router-bootstrap/issues/152