### PR TITLE
Fix heroku environment variables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+3.4.1
+===
+- PR #868
+  - Replace baseUrl variable in config with apiEndpoint
+    - This is hardcoded and no longer relying on `process.env.HOST` and `process.env.PORT`
+  - Remove unneeded process.env variables
+
 3.4
 ===
 - PR #867

--- a/app/services/topics.js
+++ b/app/services/topics.js
@@ -1,8 +1,8 @@
-import { baseURL } from '../../config/app';
+import { apiEndpoint } from '../../config/app';
 import createRestApiClient from '../utils/createRestApiClient';
 
 export default () => {
-  const client = createRestApiClient().withConfig({ baseURL });
+  const client = createRestApiClient().withConfig({ baseURL: apiEndpoint });
   return {
     getTopics: () => client.request({
       method: 'GET',

--- a/app/utils/__tests__/createRestApiClient-test.js
+++ b/app/utils/__tests__/createRestApiClient-test.js
@@ -25,10 +25,10 @@ const apiServer = () => {
 describe('RESTful api client', () => {
   let client;
   let server;
-  const BASE_URL = 'http://localhost:3001';
+  const apiEndpoint = 'http://localhost:3001';
 
   beforeEach(() => {
-    client = createRestApiClient().withConfig({ baseUrl: BASE_URL });
+    client = createRestApiClient().withConfig({ baseUrl: apiEndpoint });
 
     server = apiServer('/test');
   });

--- a/config/app.js
+++ b/config/app.js
@@ -4,7 +4,7 @@ export const isProduction = ENV === 'production';
 export const isDebug = ENV === 'development';
 export const isClient = typeof window !== 'undefined';
 
-export const baseURL = `http://${HOST}:${PORT}`;
+export const apiEndpoint = isDebug ? 'http://localhost:3000' : 'https://demo-reactgo.herokuapp.com';
 // Replace with 'UA-########-#' or similar to enable tracking
 export const trackingID = null;
 

--- a/config/app.js
+++ b/config/app.js
@@ -1,4 +1,4 @@
-import { HOST, PORT, ENV } from './env';
+import { ENV } from './env';
 
 export const isProduction = ENV === 'production';
 export const isDebug = ENV === 'development';

--- a/config/env.js
+++ b/config/env.js
@@ -1,7 +1,5 @@
 import { DB_TYPES } from './dbTypes';
 
-export const HOST = process.env.HOSTNAME || 'localhost';
-export const PORT = process.env.PORT || '3000';
 export const ENV = process.env.NODE_ENV || 'development';
 
 export const DB_TYPE = process.env.DB_TYPE || DB_TYPES.MONGO;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webpack-node",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Your One-Stop solution for a full-stack app with ES6/ES2015 React.js featuring universal Redux, React Router, React Router Redux Hot reloading, CSS modules, Express 4.x, and multiple ORMs.",
   "repository": "https://github.com/choonkending/react-webpack-node",
   "main": "index.js",


### PR DESCRIPTION
# Why

- `process.env.HOST` and `process.env.PORT` were not being piped through to our app.

After some 🤔 , decded to rename `baseUrl` to `apiEndpoint` as we have been making the assumption that the API server is the same as the rendering service host. 

In real life, this would might not be the same endpoint. Rather than adding `HOST` and `PORT` to webpack.EnvironmentPlugin, hardcoding the endpoint makes it easier to reason about. 


