### PR TITLE
update babel-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "axios": "^0.16.0",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
-    "babel-loader": "^6.4.1",
+    "babel-loader": "^7.0.0",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-transform-react-constant-elements": "^6.23.0",
     "babel-plugin-transform-react-inline-elements": "^6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,14 +459,13 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-loader@^6.4.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-6.4.1.tgz#0b34112d5b0748a8dcdbf51acf6f9bd42d50b8ca"
+babel-loader@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.0.0.tgz#2e43a66bee1fff4470533d0402c8a4532fafbaf7"
   dependencies:
     find-cache-dir "^0.1.1"
-    loader-utils "^0.2.16"
+    loader-utils "^1.0.2"
     mkdirp "^0.5.1"
-    object-assign "^4.0.1"
 
 babel-messages@^6.23.0:
   version "6.23.0"


### PR DESCRIPTION
Fixes #874 and #848 by updating `babel-loader`.

On another note, there are more deps to be bumped, with new major, minor and patch versions. I have done so in my own projects (except for `react-router`), and haven't noticed any regressions. Running `ncu` ([npm-check-updates](https://www.npmjs.com/package/npm-check-updates)) yields

```javascript
Using /home/ubuntu/workspace/package.json

 autoprefixer                                     ^6.7.7  →   ^7.0.1 
 babel-plugin-transform-react-remove-prop-types   ^0.3.3  →   ^0.4.5 
 cross-env                                        ^4.0.0  →   ^5.0.0 
 postcss-loader                                   ^1.3.3  →   ^2.0.5 
 react-router                                     ^3.0.3  →   ^4.1.1 
 style-loader                                    ^0.16.1  →  ^0.17.0 
 eslint-plugin-jsx-a11y                           ^4.0.0  →   ^5.0.1 
 eslint-plugin-react                             ^6.10.3  →   ^7.0.0 
 jsdom                                           ^9.12.0  →  ^10.1.0 
 redux-mock-store                                  1.2.2  →    1.2.3 

The following dependencies are satisfied by their declared version range, but the installed versions are behind. You can install the latest versions without modifying your package file by using npm update. If you want to update the dependencies in your package file anyway, run ncu -a.

 prop-types          ^15.5.4  →  ^15.5.9 
 react-router-redux   ^4.0.0  →   ^4.0.8 
 mocha                ^3.2.0  →   ^3.3.0 

Run ncu with -u to upgrade package.json
```