### PR TITLE
Wrap ${componentHTML} to kill checksum warning

### DIFF
--- a/server/render/pageRenderer.jsx
+++ b/server/render/pageRenderer.jsx
@@ -23,7 +23,7 @@ const buildPage = ({ componentHTML, initialState, headAssets }) => {
     ${staticAssets.createTrackingScript()}
   </head>
   <body>
-    <div id="app">${componentHTML}</div>
+    <div id="app"><div>${componentHTML}</div></div>
     <script>window.__INITIAL_STATE__ = ${JSON.stringify(initialState)}</script>
     ${staticAssets.createAppScript()}
   </body>


### PR DESCRIPTION
Wrapping ${componentHTML} with an empty &lt;div&gt; gets rid of this console warning:

*Warning: React attempted to reuse markup in a container but the checksum was invalid*