### PR TITLE
use bluebird promise library w/ mongoose

### DIFF
--- a/server/db/mongo/connect.js
+++ b/server/db/mongo/connect.js
@@ -5,6 +5,7 @@ import loadModels from './models';
 export default () => {
   // Find the appropriate database to connect to, default to localhost if not found.
   const connect = () => {
+    mongoose.Promise = require('bluebird');
     mongoose.connect(db, (err) => {
       if (err) {
         console.log(`===>  Error connecting to ${db}`);


### PR DESCRIPTION
faster mongoose promises ([read here](https://stackoverflow.com/a/41837255)) and gets rid of this build warning:

*(node:42998) DeprecationWarning: Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html*