### PR TITLE
Reduce time to DOMContentLoaded by loading the javascript asynchronously

### DIFF
--- a/server/render/static-assets/dev.js
+++ b/server/render/static-assets/dev.js
@@ -1,6 +1,6 @@
 import { GOOGLE_ANALYTICS_ID } from '../../../config/env';
 
-const createAppScript = () => '<script type="text/javascript" charset="utf-8" src="/assets/app.js"></script>';
+const createAppScript = () => '<script async type="text/javascript" charset="utf-8" src="/assets/app.js"></script>';
 
 const createTrackingScript = () => GOOGLE_ANALYTICS_ID ? createAnalyticsSnippet(GOOGLE_ANALYTICS_ID) : '';
 

--- a/server/render/static-assets/prod.js
+++ b/server/render/static-assets/prod.js
@@ -1,7 +1,7 @@
 import { GOOGLE_ANALYTICS_ID } from '../../../config/env';
 import assets from '../../../public/assets/manifest.json';
 
-const createAppScript = () => `<script type="text/javascript" charset="utf-8" src="/assets/${assets['app.js']}"></script>`;
+const createAppScript = () => `<script async type="text/javascript" charset="utf-8" src="/assets/${assets['app.js']}"></script>`;
 
 const createTrackingScript = () => GOOGLE_ANALYTICS_ID ? createAnalyticsSnippet(GOOGLE_ANALYTICS_ID) : '';
 


### PR DESCRIPTION
Because of the serverside rendering, there is no reason to wait for the entire JS to be downloaded, parsed and executed before rendering the site on the client. Adding `async` is the current best practice to achieve that.

Using `async` in dev has no effect on the development experience as far as I can tell. The CSS is already flashing on each reload and the load times are the same. So strictly speaking, it would be enough to add `async` to production only, but I prefer to have the dev env be as similar to the prod env, so that bugs and race conditions can be discovered there.