### PR TITLE
Add the user's cookie to Axios for pre-render fetching

### DIFF
--- a/config/secrets.js
+++ b/config/secrets.js
@@ -8,3 +8,5 @@ export const google = {
   callbackURL: process.env.GOOGLE_CALLBACK || '/auth/google/callback'
 };
 
+/* To make sure everything referencing the session ID knows what it is called */
+export const sessionId = 'sid';

--- a/server/init/express.js
+++ b/server/init/express.js
@@ -14,86 +14,86 @@ import { DB_TYPE, ENV } from '../../config/env';
 import { session as dbSession } from '../db';
 
 export default (app) => {
- app.set('port', (process.env.PORT || 3000));
+  app.set('port', (process.env.PORT || 3000));
 
- if (ENV === 'production') {
-  app.use(gzip());
-  // Secure your Express apps by setting various HTTP headers. Documentation: https://github.com/helmetjs/helmet
-  app.use(helmet());
- }
+  if (ENV === 'production') {
+    app.use(gzip());
+    // Secure your Express apps by setting various HTTP headers. Documentation: https://github.com/helmetjs/helmet
+    app.use(helmet());
+  }
 
- app.use(bodyParser.json());
- app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
- app.use(methodOverride());
- app.use(cookieParser());
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
+  app.use(methodOverride());
+  app.use(cookieParser());
 
- app.use(express.static(path.join(process.cwd(), 'public')));
+  app.use(express.static(path.join(process.cwd(), 'public')));
 
- // I am adding this here so that the Heroku deploy will work
- // Indicates the app is behind a front-facing proxy,
- // and to use the X-Forwarded-* headers to determine the connection and the IP address of the client.
- // NOTE: X-Forwarded-* headers are easily spoofed and the detected IP addresses are unreliable.
- // trust proxy is disabled by default.
- // When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies.
- // The req.ips property, then, contains an array of IP addresses the client is connected through.
- // To enable it, use the values described in the trust proxy options table.
- // The trust proxy setting is implemented using the proxy-addr package. For more information, see its documentation.
- // loopback - 127.0.0.1/8, ::1/128
- app.set('trust proxy', 'loopback');
- // Create a session middleware with the given options
- // Note session data is not saved in the cookie itself, just the session ID. Session data is stored server-side.
- // Options: resave: forces the session to be saved back to the session store, even if the session was never
- //                  modified during the request. Depending on your store this may be necessary, but it can also
- //                  create race conditions where a client has two parallel requests to your server and changes made
- //                  to the session in one request may get overwritten when the other request ends, even if it made no
- //                  changes(this behavior also depends on what store you're using).
- //          saveUnitialized: Forces a session that is uninitialized to be saved to the store. A session is uninitialized when
- //                  it is new but not modified. Choosing false is useful for implementing login sessions, reducing server storage
- //                  usage, or complying with laws that require permission before setting a cookie. Choosing false will also help with
- //                  race conditions where a client makes multiple parallel requests without a session
- //          secret: This is the secret used to sign the session ID cookie.
- //          name: The name of the session ID cookie to set in the response (and read from in the request).
- //          cookie: Please note that secure: true is a recommended option.
- //                  However, it requires an https-enabled website, i.e., HTTPS is necessary for secure cookies.
- //                  If secure is set, and you access your site over HTTP, the cookie will not be set.
- let sessionStore = null;
- if (!dbSession) {
-  console.warn(unsupportedMessage('session'));
- } else {
-  sessionStore = dbSession();
- }
+  // I am adding this here so that the Heroku deploy will work
+  // Indicates the app is behind a front-facing proxy,
+  // and to use the X-Forwarded-* headers to determine the connection and the IP address of the client.
+  // NOTE: X-Forwarded-* headers are easily spoofed and the detected IP addresses are unreliable.
+  // trust proxy is disabled by default.
+  // When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies.
+  // The req.ips property, then, contains an array of IP addresses the client is connected through.
+  // To enable it, use the values described in the trust proxy options table.
+  // The trust proxy setting is implemented using the proxy-addr package. For more information, see its documentation.
+  // loopback - 127.0.0.1/8, ::1/128
+  app.set('trust proxy', 'loopback');
+  // Create a session middleware with the given options
+  // Note session data is not saved in the cookie itself, just the session ID. Session data is stored server-side.
+  // Options: resave: forces the session to be saved back to the session store, even if the session was never
+  //                  modified during the request. Depending on your store this may be necessary, but it can also
+  //                  create race conditions where a client has two parallel requests to your server and changes made
+  //                  to the session in one request may get overwritten when the other request ends, even if it made no
+  //                  changes(this behavior also depends on what store you're using).
+  //          saveUnitialized: Forces a session that is uninitialized to be saved to the store. A session is uninitialized when
+  //                  it is new but not modified. Choosing false is useful for implementing login sessions, reducing server storage
+  //                  usage, or complying with laws that require permission before setting a cookie. Choosing false will also help with
+  //                  race conditions where a client makes multiple parallel requests without a session
+  //          secret: This is the secret used to sign the session ID cookie.
+  //          name: The name of the session ID cookie to set in the response (and read from in the request).
+  //          cookie: Please note that secure: true is a recommended option.
+  //                  However, it requires an https-enabled website, i.e., HTTPS is necessary for secure cookies.
+  //                  If secure is set, and you access your site over HTTP, the cookie will not be set.
+  let sessionStore = null;
+  if (!dbSession) {
+    console.warn(unsupportedMessage('session'));
+  } else {
+    sessionStore = dbSession();
+  }
 
- const sess = {
-  resave: false,
-  saveUninitialized: false,
-  secret: sessionSecret,
-  proxy: true, // The "X-Forwarded-Proto" header will be used.
-  name: sessionId,
-  // Add HTTPOnly, Secure attributes on Session Cookie
-  // If secure is set, and you access your site over HTTP, the cookie will not be set
-  cookie: {
-   httpOnly: true,
-   secure: false,
-  },
-  store: sessionStore
- };
+  const sess = {
+    resave: false,
+    saveUninitialized: false,
+    secret: sessionSecret,
+    proxy: true, // The "X-Forwarded-Proto" header will be used.
+    name: sessionId,
+    // Add HTTPOnly, Secure attributes on Session Cookie
+    // If secure is set, and you access your site over HTTP, the cookie will not be set
+    cookie: {
+      httpOnly: true,
+      secure: false,
+    },
+    store: sessionStore
+  };
 
- console.log('--------------------------');
- console.log('===> 😊  Starting Server . . .');
- console.log(`===>  Environment: ${ENV}`);
- console.log(`===>  Listening on port: ${app.get('port')}`);
- console.log(`===>  Using DB TYPE: ${DB_TYPE}`);
- if (ENV === 'production') {
-  console.log('===> 🚦  Note: In order for authentication to work in production');
-  console.log('===>           you will need a secure HTTPS connection');
-  sess.cookie.secure = true; // Serve secure cookies
- }
- console.log('--------------------------');
+  console.log('--------------------------');
+  console.log('===> 😊  Starting Server . . .');
+  console.log(`===>  Environment: ${ENV}`);
+  console.log(`===>  Listening on port: ${app.get('port')}`);
+  console.log(`===>  Using DB TYPE: ${DB_TYPE}`);
+  if (ENV === 'production') {
+    console.log('===> 🚦  Note: In order for authentication to work in production');
+    console.log('===>           you will need a secure HTTPS connection');
+    sess.cookie.secure = true; // Serve secure cookies
+  }
+  console.log('--------------------------');
 
- app.use(session(sess));
+  app.use(session(sess));
 
- app.use(passport.initialize());
- app.use(passport.session());
+  app.use(passport.initialize());
+  app.use(passport.session());
 
- app.use(flash());
+  app.use(flash());
 };

--- a/server/init/express.js
+++ b/server/init/express.js
@@ -2,97 +2,98 @@ import express from 'express';
 import passport from 'passport';
 import session from 'express-session';
 import bodyParser from 'body-parser';
+import cookieParser from 'cookie-parser';
 import path from 'path';
 import flash from 'express-flash';
 import methodOverride from 'method-override';
 import gzip from 'compression';
 import helmet from 'helmet';
 import unsupportedMessage from '../db/unsupportedMessage';
-import { sessionSecret } from '../../config/secrets';
+import { sessionSecret, sessionId } from '../../config/secrets';
 import { DB_TYPE, ENV } from '../../config/env';
 import { session as dbSession } from '../db';
 
 export default (app) => {
-  app.set('port', (process.env.PORT || 3000));
+ app.set('port', (process.env.PORT || 3000));
 
-  if (ENV === 'production') {
-    app.use(gzip());
-    // Secure your Express apps by setting various HTTP headers. Documentation: https://github.com/helmetjs/helmet
-    app.use(helmet());
-  }
+ if (ENV === 'production') {
+  app.use(gzip());
+  // Secure your Express apps by setting various HTTP headers. Documentation: https://github.com/helmetjs/helmet
+  app.use(helmet());
+ }
 
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
-  app.use(methodOverride());
+ app.use(bodyParser.json());
+ app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
+ app.use(methodOverride());
+ app.use(cookieParser());
 
-  app.use(express.static(path.join(process.cwd(), 'public')));
+ app.use(express.static(path.join(process.cwd(), 'public')));
 
-  // I am adding this here so that the Heroku deploy will work
-  // Indicates the app is behind a front-facing proxy,
-  // and to use the X-Forwarded-* headers to determine the connection and the IP address of the client.
-  // NOTE: X-Forwarded-* headers are easily spoofed and the detected IP addresses are unreliable.
-  // trust proxy is disabled by default.
-  // When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies.
-  // The req.ips property, then, contains an array of IP addresses the client is connected through.
-  // To enable it, use the values described in the trust proxy options table.
-  // The trust proxy setting is implemented using the proxy-addr package. For more information, see its documentation.
-  // loopback - 127.0.0.1/8, ::1/128
-  app.set('trust proxy', 'loopback');
-  // Create a session middleware with the given options
-  // Note session data is not saved in the cookie itself, just the session ID. Session data is stored server-side.
-  // Options: resave: forces the session to be saved back to the session store, even if the session was never
-  //                  modified during the request. Depending on your store this may be necessary, but it can also
-  //                  create race conditions where a client has two parallel requests to your server and changes made
-  //                  to the session in one request may get overwritten when the other request ends, even if it made no
-  //                  changes(this behavior also depends on what store you're using).
-  //          saveUnitialized: Forces a session that is uninitialized to be saved to the store. A session is uninitialized when
-  //                  it is new but not modified. Choosing false is useful for implementing login sessions, reducing server storage
-  //                  usage, or complying with laws that require permission before setting a cookie. Choosing false will also help with
-  //                  race conditions where a client makes multiple parallel requests without a session
-  //          secret: This is the secret used to sign the session ID cookie.
-  //          name: The name of the session ID cookie to set in the response (and read from in the request).
-  //          cookie: Please note that secure: true is a recommended option.
-  //                  However, it requires an https-enabled website, i.e., HTTPS is necessary for secure cookies.
-  //                  If secure is set, and you access your site over HTTP, the cookie will not be set.
-  let sessionStore = null;
-  if (!dbSession) {
-    console.warn(unsupportedMessage('session'));
-  } else {
-    sessionStore = dbSession();
-  }
+ // I am adding this here so that the Heroku deploy will work
+ // Indicates the app is behind a front-facing proxy,
+ // and to use the X-Forwarded-* headers to determine the connection and the IP address of the client.
+ // NOTE: X-Forwarded-* headers are easily spoofed and the detected IP addresses are unreliable.
+ // trust proxy is disabled by default.
+ // When enabled, Express attempts to determine the IP address of the client connected through the front-facing proxy, or series of proxies.
+ // The req.ips property, then, contains an array of IP addresses the client is connected through.
+ // To enable it, use the values described in the trust proxy options table.
+ // The trust proxy setting is implemented using the proxy-addr package. For more information, see its documentation.
+ // loopback - 127.0.0.1/8, ::1/128
+ app.set('trust proxy', 'loopback');
+ // Create a session middleware with the given options
+ // Note session data is not saved in the cookie itself, just the session ID. Session data is stored server-side.
+ // Options: resave: forces the session to be saved back to the session store, even if the session was never
+ //                  modified during the request. Depending on your store this may be necessary, but it can also
+ //                  create race conditions where a client has two parallel requests to your server and changes made
+ //                  to the session in one request may get overwritten when the other request ends, even if it made no
+ //                  changes(this behavior also depends on what store you're using).
+ //          saveUnitialized: Forces a session that is uninitialized to be saved to the store. A session is uninitialized when
+ //                  it is new but not modified. Choosing false is useful for implementing login sessions, reducing server storage
+ //                  usage, or complying with laws that require permission before setting a cookie. Choosing false will also help with
+ //                  race conditions where a client makes multiple parallel requests without a session
+ //          secret: This is the secret used to sign the session ID cookie.
+ //          name: The name of the session ID cookie to set in the response (and read from in the request).
+ //          cookie: Please note that secure: true is a recommended option.
+ //                  However, it requires an https-enabled website, i.e., HTTPS is necessary for secure cookies.
+ //                  If secure is set, and you access your site over HTTP, the cookie will not be set.
+ let sessionStore = null;
+ if (!dbSession) {
+  console.warn(unsupportedMessage('session'));
+ } else {
+  sessionStore = dbSession();
+ }
 
-  const sess = {
-    resave: false,
-    saveUninitialized: false,
-    secret: sessionSecret,
-    proxy: true, // The "X-Forwarded-Proto" header will be used.
-    name: 'sessionId',
-    // Add HTTPOnly, Secure attributes on Session Cookie
-    // If secure is set, and you access your site over HTTP, the cookie will not be set
-    cookie: {
-      httpOnly: true,
-      secure: false,
-    },
-    store: sessionStore
-  };
+ const sess = {
+  resave: false,
+  saveUninitialized: false,
+  secret: sessionSecret,
+  proxy: true, // The "X-Forwarded-Proto" header will be used.
+  name: sessionId,
+  // Add HTTPOnly, Secure attributes on Session Cookie
+  // If secure is set, and you access your site over HTTP, the cookie will not be set
+  cookie: {
+   httpOnly: true,
+   secure: false,
+  },
+  store: sessionStore
+ };
 
-  console.log('--------------------------');
-  console.log('===> 😊  Starting Server . . .');
-  console.log(`===>  Environment: ${ENV}`);
-  console.log(`===>  Listening on port: ${app.get('port')}`);
-  console.log(`===>  Using DB TYPE: ${DB_TYPE}`);
-  if (ENV === 'production') {
-    console.log('===> 🚦  Note: In order for authentication to work in production');
-    console.log('===>           you will need a secure HTTPS connection');
-    sess.cookie.secure = true; // Serve secure cookies
-  }
-  console.log('--------------------------');
+ console.log('--------------------------');
+ console.log('===> 😊  Starting Server . . .');
+ console.log(`===>  Environment: ${ENV}`);
+ console.log(`===>  Listening on port: ${app.get('port')}`);
+ console.log(`===>  Using DB TYPE: ${DB_TYPE}`);
+ if (ENV === 'production') {
+  console.log('===> 🚦  Note: In order for authentication to work in production');
+  console.log('===>           you will need a secure HTTPS connection');
+  sess.cookie.secure = true; // Serve secure cookies
+ }
+ console.log('--------------------------');
 
+ app.use(session(sess));
 
-  app.use(session(sess));
+ app.use(passport.initialize());
+ app.use(passport.session());
 
-  app.use(passport.initialize());
-  app.use(passport.session());
-
-  app.use(flash());
+ app.use(flash());
 };

--- a/server/render/middleware.js
+++ b/server/render/middleware.js
@@ -1,9 +1,11 @@
 import { createMemoryHistory, match } from 'react-router';
+import axios from 'axios';
 import createRoutes from '../../app/routes';
 import configureStore from '../../app/store/configureStore';
 import * as types from '../../app/types';
 import pageRenderer from './pageRenderer';
 import fetchDataForRoute from '../../app/utils/fetchDataForRoute';
+import { sessionId } from '../../config/secrets';
 
 /*
  * Export render function to be used in server/config/routes.js
@@ -11,60 +13,65 @@ import fetchDataForRoute from '../../app/utils/fetchDataForRoute';
  * and pass it into the Router.run function.
  */
 export default function render(req, res) {
-  const authenticated = req.isAuthenticated();
-  const history = createMemoryHistory();
-  const store = configureStore({
-    user: {
-      authenticated,
-      isWaiting: false,
-      message: '',
-      isLogin: true
-    }
-  }, history);
-  const routes = createRoutes(store);
+ const authenticated = req.isAuthenticated();
+ const history = createMemoryHistory();
+ const store = configureStore({
+  user: {
+   authenticated,
+   isWaiting: false,
+   message: '',
+   isLogin: true
+  }
+ }, history);
+ const routes = createRoutes(store);
 
-  /*
-   * From the react-router docs:
-   *
-   * This function is to be used for server-side rendering. It matches a set of routes to
-   * a location, without rendering, and calls a callback(err, redirect, props)
-   * when it's done.
-   *
-   * The function will create a `history` for you, passing additional `options` to create it.
-   * These options can include `basename` to control the base name for URLs, as well as the pair
-   * of `parseQueryString` and `stringifyQuery` to control query string parsing and serializing.
-   * You can also pass in an already instantiated `history` object, which can be constructed
-   * however you like.
-   *
-   * The three arguments to the callback function you pass to `match` are:
-   * - err:       A javascript Error object if an error occurred, `undefined` otherwise.
-   * - redirect:  A `Location` object if the route is a redirect, `undefined` otherwise
-   * - props:     The props you should pass to the routing context if the route matched,
-   *              `undefined` otherwise.
-   * If all three parameters are `undefined`, this means that there was no route found matching the
-   * given location.
-   */
-  match({routes, location: req.url}, (err, redirect, props) => {
-    if (err) {
+ /*
+  * From the react-router docs:
+  *
+  * This function is to be used for server-side rendering. It matches a set of routes to
+  * a location, without rendering, and calls a callback(err, redirect, props)
+  * when it's done.
+  *
+  * The function will create a `history` for you, passing additional `options` to create it.
+  * These options can include `basename` to control the base name for URLs, as well as the pair
+  * of `parseQueryString` and `stringifyQuery` to control query string parsing and serializing.
+  * You can also pass in an already instantiated `history` object, which can be constructed
+  * however you like.
+  *
+  * The three arguments to the callback function you pass to `match` are:
+  * - err:       A javascript Error object if an error occurred, `undefined` otherwise.
+  * - redirect:  A `Location` object if the route is a redirect, `undefined` otherwise
+  * - props:     The props you should pass to the routing context if the route matched,
+  *              `undefined` otherwise.
+  * If all three parameters are `undefined`, this means that there was no route found matching the
+  * given location.
+  */
+ match({ routes, location: req.url }, (err, redirect, props) => {
+  /* Give the user's session to the server to use */
+  if (req.cookies[sessionId]) {
+   axios.defaults.headers.common.Cookie = sessionId + '=' + req.cookies[sessionId];
+  }
+
+  if (err) {
+   res.status(500).json(err);
+  } else if (redirect) {
+   res.redirect(302, redirect.pathname + redirect.search);
+  } else if (props) {
+   // This method waits for all render component
+   // promises to resolve before returning to browser
+   store.dispatch({ type: types.CREATE_REQUEST });
+   fetchDataForRoute(props)
+     .then((data) => {
+      store.dispatch({ type: types.REQUEST_SUCCESS, data });
+      const html = pageRenderer(store, props);
+      res.status(200).send(html);
+     })
+     .catch((err) => {
+      console.error(err);
       res.status(500).json(err);
-    } else if (redirect) {
-      res.redirect(302, redirect.pathname + redirect.search);
-    } else if (props) {
-      // This method waits for all render component
-      // promises to resolve before returning to browser
-      store.dispatch({ type: types.CREATE_REQUEST });
-      fetchDataForRoute(props)
-        .then((data) => {
-          store.dispatch({ type: types.REQUEST_SUCCESS, data });
-          const html = pageRenderer(store, props);
-          res.status(200).send(html);
-        })
-        .catch((err) => {
-          console.error(err);
-          res.status(500).json(err);
-        });
-    } else {
-      res.sendStatus(404);
-    }
-  });
+     });
+  } else {
+   res.sendStatus(404);
+  }
+ });
 }

--- a/server/render/middleware.js
+++ b/server/render/middleware.js
@@ -13,65 +13,65 @@ import { sessionId } from '../../config/secrets';
  * and pass it into the Router.run function.
  */
 export default function render(req, res) {
- const authenticated = req.isAuthenticated();
- const history = createMemoryHistory();
- const store = configureStore({
-  user: {
-   authenticated,
-   isWaiting: false,
-   message: '',
-   isLogin: true
-  }
- }, history);
- const routes = createRoutes(store);
+  const authenticated = req.isAuthenticated();
+  const history = createMemoryHistory();
+  const store = configureStore({
+    user: {
+      authenticated,
+      isWaiting: false,
+      message: '',
+      isLogin: true
+    }
+  }, history);
+  const routes = createRoutes(store);
 
- /*
-  * From the react-router docs:
-  *
-  * This function is to be used for server-side rendering. It matches a set of routes to
-  * a location, without rendering, and calls a callback(err, redirect, props)
-  * when it's done.
-  *
-  * The function will create a `history` for you, passing additional `options` to create it.
-  * These options can include `basename` to control the base name for URLs, as well as the pair
-  * of `parseQueryString` and `stringifyQuery` to control query string parsing and serializing.
-  * You can also pass in an already instantiated `history` object, which can be constructed
-  * however you like.
-  *
-  * The three arguments to the callback function you pass to `match` are:
-  * - err:       A javascript Error object if an error occurred, `undefined` otherwise.
-  * - redirect:  A `Location` object if the route is a redirect, `undefined` otherwise
-  * - props:     The props you should pass to the routing context if the route matched,
-  *              `undefined` otherwise.
-  * If all three parameters are `undefined`, this means that there was no route found matching the
-  * given location.
-  */
- match({ routes, location: req.url }, (err, redirect, props) => {
-  /* Give the user's session to the server to use */
-  if (req.cookies[sessionId]) {
-   axios.defaults.headers.common.Cookie = sessionId + '=' + req.cookies[sessionId];
-  }
+  /*
+   * From the react-router docs:
+   *
+   * This function is to be used for server-side rendering. It matches a set of routes to
+   * a location, without rendering, and calls a callback(err, redirect, props)
+   * when it's done.
+   *
+   * The function will create a `history` for you, passing additional `options` to create it.
+   * These options can include `basename` to control the base name for URLs, as well as the pair
+   * of `parseQueryString` and `stringifyQuery` to control query string parsing and serializing.
+   * You can also pass in an already instantiated `history` object, which can be constructed
+   * however you like.
+   *
+   * The three arguments to the callback function you pass to `match` are:
+   * - err:       A javascript Error object if an error occurred, `undefined` otherwise.
+   * - redirect:  A `Location` object if the route is a redirect, `undefined` otherwise
+   * - props:     The props you should pass to the routing context if the route matched,
+   *              `undefined` otherwise.
+   * If all three parameters are `undefined`, this means that there was no route found matching the
+   * given location.
+   */
+  match({ routes, location: req.url }, (err, redirect, props) => {
+    /* Give the user's session to the server to use */
+    if (req.cookies[sessionId]) {
+      axios.defaults.headers.common.Cookie = sessionId + '=' + req.cookies[sessionId];
+    }
 
-  if (err) {
-   res.status(500).json(err);
-  } else if (redirect) {
-   res.redirect(302, redirect.pathname + redirect.search);
-  } else if (props) {
-   // This method waits for all render component
-   // promises to resolve before returning to browser
-   store.dispatch({ type: types.CREATE_REQUEST });
-   fetchDataForRoute(props)
-     .then((data) => {
-      store.dispatch({ type: types.REQUEST_SUCCESS, data });
-      const html = pageRenderer(store, props);
-      res.status(200).send(html);
-     })
-     .catch((err) => {
-      console.error(err);
+    if (err) {
       res.status(500).json(err);
-     });
-  } else {
-   res.sendStatus(404);
-  }
- });
+    } else if (redirect) {
+      res.redirect(302, redirect.pathname + redirect.search);
+    } else if (props) {
+      // This method waits for all render component
+      // promises to resolve before returning to browser
+      store.dispatch({ type: types.CREATE_REQUEST });
+      fetchDataForRoute(props)
+        .then((data) => {
+          store.dispatch({ type: types.REQUEST_SUCCESS, data });
+          const html = pageRenderer(store, props);
+          res.status(200).send(html);
+        })
+        .catch((err) => {
+          console.error(err);
+          res.status(500).json(err);
+        });
+    } else {
+      res.sendStatus(404);
+    }
+  });
 }


### PR DESCRIPTION
This is in response to #435 and #225 - where the user's session is not available to the server for pre-render data fetching. 

## Problem 
Data fetching happens before the response if sent to the user. This means that the request is coming from the server, to the server. These queries may need access to req.user, which is not available because the request has come from the server. 

## Solution
Add the user's session cookie to axios.defaults.headers.common.Cookie so passport can deserialize the user, giving access to req.user. 

## Test
Add console.log('User from request', req.user) to the all function in  /controller/topics/
Log into the application
See that the user has been attached to the request object

I also added the sessionID to the secrets file. This is because the user may change the name of this in the cookie declaration and this solution will no longer work. Adding it to a centralised location means the user can change the name of the session cookie and it will be changed everywhere that it is used. 