### PR TITLE
Remove unneeded path to bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/choonkending/react-webpack-node",
   "main": "index.js",
   "scripts": {
-    "sequelize": "node_modules/.bin/sequelize",
+    "sequelize": "sequelize",
     "lint": "eslint --ext .js,.jsx app server",
     "lint:fix": "eslint --ext .js,.jsx app server --fix",
     "clean": "rimraf public && rimraf compiled",


### PR DESCRIPTION
Assuming the `node_modules` is in the root of the project is not a good idea. In certain scenarios, like `yarn` `workspaces`, the `node_modules` could get hoisted up. The script will work the same without the path specification.